### PR TITLE
trim leading zero for signature r and s

### DIFF
--- a/lib/eth/transaction/signer.ex
+++ b/lib/eth/transaction/signer.ex
@@ -124,7 +124,10 @@ defmodule ETH.Transaction.Signer do
 
     sig_v = if chain_id > 0, do: initial_v + (chain_id * 2 + 8), else: initial_v
 
-    [nonce, gas_price, gas_limit, to, value, data, <<sig_v>>, sig_r, sig_s]
+    [nonce, gas_price, gas_limit, to, value, data, <<sig_v>>, trim_leading_zero(sig_r), trim_leading_zero(sig_s)]
     |> ExRLP.encode()
   end
+
+  defp trim_leading_zero(<<0>> <> r_or_s), do: r_or_s
+  defp trim_leading_zero(r_or_s), do: r_or_s
 end


### PR DESCRIPTION
hey there, thanks for your good work.

after signing transaction using `%{data: xxx, nonce: xxx, ...} |> ETH.parse() |> ETH.sign_transaction(pkey)`, if the generated signature `r` or `s` has a leading zero `<<0>>`, the transaction sending call will get an error from the ethereum endpoint:

`rlp: non-canonical integer (leading zero bytes) for *big.Int, decoding into (types.Transaction)(types.txdata).R`

it has been mentioned years ago:

[https://ethereum.stackexchange.com/questions/71616/ethereum-boardcast-shows-error-non-canonical-integer-leading-zero-bytes-for](https://ethereum.stackexchange.com/questions/71616/ethereum-boardcast-shows-error-non-canonical-integer-leading-zero-bytes-for)

it's not a mistake, neither a bug, it looks like a, hmm..., specification conflict?

after digging it for hours, i reproduced it successfully, got an `s` like this:

<<**`0`**, 107, 148, 141, 178, 99, 64, 168, 233, 83, 227, 146, 181, 23, 67, 73, 156, 25, 30, 221, 168, 80, 241, 88, 51, 232, 102, 213, 157, 18, 130, 225>>

i tried and tested, found that the most convenient way to solve this problem is to trim the leading zero from signature `r` or `s` directly.

hope it helps, thank you so much.