### PR TITLE
Use Keyword/Map `get_lazy` function when computing default values

### DIFF
--- a/lib/eth/transaction.ex
+++ b/lib/eth/transaction.ex
@@ -221,10 +221,10 @@ defmodule ETH.Transaction do
   end
 
   defp set_default_from(params, private_key) when is_list(params) do
-    put_in(params, [:from], Keyword.get(params, :from, get_address(private_key)))
+    put_in(params, [:from], Keyword.get_lazy(params, :from, fn -> get_address(private_key) end))
   end
 
   defp set_default_from(params, private_key) when is_map(params) do
-    Map.merge(params, %{from: Map.get(params, :from, get_address(private_key))})
+    Map.merge(params, %{from: Map.get_lazy(params, :from, fn -> get_address(private_key) end)})
   end
 end

--- a/lib/eth/transaction/builder.ex
+++ b/lib/eth/transaction/builder.ex
@@ -65,7 +65,7 @@ defmodule ETH.Transaction.Builder do
   defp build_params_from_list(params) do
     to = Keyword.get(params, :to, "")
     value = Keyword.get(params, :value, 0)
-    gas_price = Keyword.get(params, :gas_price, ETH.gas_price!())
+    gas_price = Keyword.get_lazy(params, :gas_price, fn -> ETH.gas_price!() end)
     data = Keyword.get(params, :data, "")
 
     target_data =
@@ -73,20 +73,22 @@ defmodule ETH.Transaction.Builder do
         do: "0x" <> Hexate.encode(data),
         else: data
 
-    nonce = Keyword.get(params, :nonce, generate_nonce(Keyword.get(params, :from)))
+    nonce = Keyword.get_lazy(params, :nonce, fn -> generate_nonce(Keyword.get(params, :from)) end)
     chain_id = Keyword.get(params, :chain_id, 3)
 
     gas_limit =
-      Keyword.get(
+      Keyword.get_lazy(
         params,
         :gas_limit,
-        ETH.estimate_gas!(%{
-          to: to,
-          value: value,
-          data: target_data,
-          nonce: nonce,
-          chain_id: chain_id
-        })
+        fn ->
+          ETH.estimate_gas!(%{
+            to: to,
+            value: value,
+            data: target_data,
+            nonce: nonce,
+            chain_id: chain_id
+          })
+        end
       )
 
     %{
@@ -102,7 +104,7 @@ defmodule ETH.Transaction.Builder do
   defp build_params_from_map(params) do
     to = Map.get(params, :to, "")
     value = Map.get(params, :value, 0)
-    gas_price = Map.get(params, :gas_price, ETH.gas_price!())
+    gas_price = Map.get_lazy(params, :gas_price, fn -> ETH.gas_price!() end)
     data = Map.get(params, :data, "")
 
     target_data =
@@ -110,20 +112,22 @@ defmodule ETH.Transaction.Builder do
         do: "0x" <> Hexate.encode(data),
         else: data
 
-    nonce = Map.get(params, :nonce, generate_nonce(Map.get(params, :from)))
+    nonce = Map.get_lazy(params, :nonce, fn -> generate_nonce(Map.get(params, :from)) end)
     chain_id = Map.get(params, :chain_id, 3)
 
     gas_limit =
-      Map.get(
+      Map.get_lazy(
         params,
         :gas_limit,
-        ETH.estimate_gas!(%{
-          to: to,
-          value: value,
-          data: target_data,
-          nonce: nonce,
-          chain_id: chain_id
-        })
+        fn ->
+          ETH.estimate_gas!(%{
+            to: to,
+            value: value,
+            data: target_data,
+            nonce: nonce,
+            chain_id: chain_id
+          })
+        end
       )
 
     %{


### PR DESCRIPTION
I found that `estimate_gas` will always be called even if I already put a `gas_limit` in my transaction. This PR makes sure that all computed values for `Keyword.get` and `Map.get` will get computed lazily which entails changing those calls to `Keyword.get_lazy` and `Map.get_lazy`, respectively.