### PR TITLE
Add `chain_id` when building transaction

### DIFF
--- a/lib/eth/transaction/builder.ex
+++ b/lib/eth/transaction/builder.ex
@@ -92,6 +92,7 @@ defmodule ETH.Transaction.Builder do
       )
 
     %{
+      chain_id: chain_id,
       nonce: nonce,
       gas_price: gas_price,
       gas_limit: gas_limit,
@@ -131,6 +132,7 @@ defmodule ETH.Transaction.Builder do
       )
 
     %{
+      chain_id: chain_id,
       nonce: nonce,
       gas_price: gas_price,
       gas_limit: gas_limit,

--- a/lib/eth/utils.ex
+++ b/lib/eth/utils.ex
@@ -93,8 +93,7 @@ defmodule ETH.Utils do
 
   # defp buffer_to_int(""), do: 0
   def buffer_to_int(data) do
-    <<number>> = to_buffer(data)
-    number
+    data |> to_buffer() |> :binary.decode_unsigned()
   end
 
   def pad_to_even(data) do


### PR DESCRIPTION
### Task list

- [x] Add `chain_id` to `Builder`
- [x] Fix bug when decoding the `chain_id` -- allow it to be larger than one byte
- [ ] Add `chain_id` to `Signer`