### PR TITLE
Handle errors when gas_limit is calculated

### DIFF
--- a/lib/eth/query.ex
+++ b/lib/eth/query.ex
@@ -155,17 +155,21 @@ defmodule ETH.Query do
       {:ok, hex_gas_estimate} ->
         {:ok, hex_gas_estimate |> convert_to_number |> convert(denomination) |> round}
 
-      error ->
-        error
+      {:error, error} ->
+        {:error, error}
     end
   end
 
   def estimate_gas!(transaction \\ %{data: ""}, denomaination \\ :wei)
 
   def estimate_gas!(transaction = %{to: _to, data: _data}, denomination) do
-    {:ok, hex_gas_estimate} = HttpClient.eth_estimate_gas(transaction)
+    case HttpClient.eth_estimate_gas(transaction) do
+      {:ok, hex_gas_estimate} ->
+        hex_gas_estimate |> convert_to_number |> convert(denomination) |> round
 
-    hex_gas_estimate |> convert_to_number |> convert(denomination) |> round
+      {:error, error} ->
+        {:error, error}
+    end
   end
 
   def convert_transaction_log(log) do

--- a/lib/eth/transaction.ex
+++ b/lib/eth/transaction.ex
@@ -26,9 +26,12 @@ defmodule ETH.Transaction do
   def send_transaction(params, private_key) do
     set_default_from(params, private_key)
     |> build
-    |> sign_transaction(private_key)
-    |> Base.encode16()
-    |> send
+    |> case do
+      %{gas_limit: {:error, error}} -> {:error, error}
+      build -> sign_transaction(build, private_key)
+      |> Base.encode16()
+      |> send
+    end
   end
 
   def send_transaction(sender_wallet, receiver_wallet, value) when is_number(value) do


### PR DESCRIPTION
When I have some guard on my contract like `is_owner` this throws an unhandled exception on the gas_limit calculation. I added a simple error tuple to be able to capture the event and don't kill my genserver while sending transactions.

Example of error I got before the change:

```
** (MatchError) no match of right hand side value: {:error, %{"code" => -32000, "data" => %{"hash" => nil, "message" => "revert", "programCounter" => 3727, "reason" => "Sender no autorizado.", "result" => "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001553656e646572206e6f206175746f72697a61646f2e0000000000000000000000"}, "message" => "VM Exception while processing transaction: revert Sender no autorizado.", "name" => "RuntimeError", "stack" => "RuntimeError: VM Exception while processing transaction: revert Sender no autorizado.\n    at exactimate (/Applications/Ganache.app/Contents/Resources/static/node/node_modules/ganache/dist/node/1.js:2:182136)"}}
    (eth 0.6.7) lib/eth/query.ex:166: ETH.Query.estimate_gas!/2
    (eth 0.6.7) lib/eth/transaction/builder.ex:120: ETH.Transaction.Builder.build_params_from_map/1
    (eth 0.6.7) lib/eth/transaction/builder.ex:19: ETH.Transaction.Builder.build/1
    (eth 0.6.7) lib/eth/transaction.ex:28: ETH.Transaction.send_transaction/2
    ```